### PR TITLE
refactor: #105 회원가입 로직 리팩토링

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+import { ACCESS_TOKEN } from "@/utils/constant";
 import { navigateTo } from "@/utils/globalNavigate";
 import axios, {
   AxiosError,
@@ -30,7 +31,7 @@ const logOnDev = (message: string) => {
 const onError = (status: number, message: string) => {
   const error = { status, message };
   if (status === 401) {
-    localStorage.removeItem("FLOWBIT_ACT");
+    localStorage.removeItem(ACCESS_TOKEN);
     navigateTo("/signin");
   }
   throw error;
@@ -40,7 +41,7 @@ const onError = (status: number, message: string) => {
 const onRequest = (
   config: AxiosRequestConfig,
 ): Promise<InternalAxiosRequestConfig> => {
-  const token = localStorage.getItem("FLOWBIT_ACT");
+  const token = localStorage.getItem(ACCESS_TOKEN);
   const { method, url, headers = {} } = config;
 
   headers.Authorization = token ? `Bearer ${token}` : "";

--- a/src/app/oauth2/redierct/index.tsx
+++ b/src/app/oauth2/redierct/index.tsx
@@ -1,5 +1,6 @@
 import { loginState } from "@/store/user";
-import { useAtom } from "jotai";
+import { ACCESS_TOKEN } from "@/utils/constant";
+import { useSetAtom } from "jotai";
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -8,17 +9,17 @@ export default function Oauth2Redirect() {
   const navigate = useNavigate();
   const params = new URLSearchParams(location.search);
   const accessToken = params.get("accessToken");
-  const [_, setLogin] = useAtom(loginState);
+  const setLogin = useSetAtom(loginState);
 
   useEffect(() => {
     if (accessToken) {
-      localStorage.setItem("FLOWBIT_ACT", accessToken);
+      localStorage.setItem(ACCESS_TOKEN, accessToken);
       setLogin(true);
       navigate("/");
-    }else {
-      alert("오류가 발생했어요, 관리자에게 문의해주세요")
+    } else {
+      alert("오류가 발생했어요, 관리자에게 문의해주세요");
     }
-  }, [accessToken]);
+  }, []);
 
   return <>처리중입니다.</>;
 }

--- a/src/app/signin/index.tsx
+++ b/src/app/signin/index.tsx
@@ -12,33 +12,31 @@ import SplitLine from "@/components/common/SplitLine.tsx";
 import { useEffect, useState } from "react";
 import { signIn } from "@/hooks/api/member/useApiSignIn.ts";
 import { loginState } from "@/store/user";
-import { useAtom } from "jotai";
-import { ACT } from "@/utils/common";
+import { useSetAtom } from "jotai";
+import { ACCESS_TOKEN, OAUTH } from "@/utils/constant";
+import useCheckEmail from "@/hooks/useCheckEmail";
 
 export default function SignIn() {
   const navigate = useNavigate();
-  const [email, setEmail] = useState("");
-  const [emailCheck, setEmailCheck] = useState(false);
+  const setLogin = useSetAtom(loginState);
+  const { email, isValidEmail, handleEmailChange } = useCheckEmail();
   const [password, setPassword] = useState("");
-  const EMAIL_REGEX =
-    /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
-  const [_, setLogin] = useAtom(loginState);
-  const googleURL =
-    "https://api.flowbit.co.kr/user-service/oauth2/authorization/google";
-  const kakaoURL =
-    "https://api.flowbit.co.kr/user-service/oauth2/authorization/kakao";
 
   useEffect(() => {
-    if (localStorage.getItem(ACT)) {
-      localStorage.removeItem(ACT);
+    if (localStorage.getItem(ACCESS_TOKEN)) {
+      localStorage.removeItem(ACCESS_TOKEN);
       setLogin(false);
     }
   }, []);
 
+  const handleSignInSocialLogin = (url: string) => {
+    window.location.href = url;
+  };
+
   const handleSignIn = async () => {
     signIn({ email, password })
       .then((res) => {
-        localStorage.setItem("FLOWBIT_ACT", res.data.accessToken);
+        localStorage.setItem(ACCESS_TOKEN, res.data.accessToken);
         setLogin(true);
         navigate("/community");
       })
@@ -74,14 +72,7 @@ export default function SignIn() {
         <Input
           icon={mail}
           placeholder={`이메일을 입력해주세요`}
-          onChange={(e) => {
-            if (e.target.value.match(EMAIL_REGEX)) {
-              setEmailCheck(true);
-            } else {
-              setEmailCheck(false);
-            }
-            setEmail(e.target.value);
-          }}
+          onChange={handleEmailChange}
         />
         <Input
           type="password"
@@ -94,7 +85,7 @@ export default function SignIn() {
         css={css`
           margin-top: 5.6rem;
         `}
-        state={emailCheck && password.length > 5}
+        state={isValidEmail && password.length > 5}
         onClick={handleSignIn}
       >
         로그인
@@ -139,7 +130,7 @@ export default function SignIn() {
               background: #fede35;
               color: #3c1e1e;
             `}
-            onClick={() => (window.location.href = kakaoURL)}
+            onClick={() => handleSignInSocialLogin(OAUTH.KAKAO)}
           >
             카카오 로그인
           </Button>
@@ -149,7 +140,7 @@ export default function SignIn() {
               background: #eeeeee;
               color: #3c1e1e;
             `}
-            onClick={() => (window.location.href = googleURL)}
+            onClick={() => handleSignInSocialLogin(OAUTH.GOOGLE)}
           >
             구글 로그인
           </Button>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -18,6 +18,7 @@ import Logo from "../common/logo";
 import { useModal } from "@/hooks/useModal.ts";
 import { loginState } from "@/store/user";
 import { useAtom } from "jotai";
+import { ACCESS_TOKEN } from "@/utils/constant";
 
 export default function Header({
   isScroll,
@@ -252,7 +253,7 @@ export default function Header({
                     content:
                       "오늘도 플로우빗 서비스를 이용해주셔서 감사합니다.\n확인 버튼을 통해 서비스 로그아웃이 가능해요",
                     callBack: () => {
-                      localStorage.removeItem("FLOWBIT_ACT");
+                      localStorage.removeItem(ACCESS_TOKEN);
                       setLogin(false);
                       close();
                       navigation(HOME_URL);

--- a/src/hooks/useCheckEmail.ts
+++ b/src/hooks/useCheckEmail.ts
@@ -1,0 +1,19 @@
+import { EMAIL_REGEX } from "@/utils/regex";
+import { ChangeEvent, useCallback, useState } from "react";
+
+export default function useCheckEmail() {
+  const [email, setEmail] = useState("");
+  const [isValidEmail, setIsValidEmail] = useState(false);
+
+  const handleEmailChange = useCallback((e: ChangeEvent) => {
+    const { value } = e.target as HTMLInputElement;
+    setEmail(value);
+    setIsValidEmail(value.match(EMAIL_REGEX) !== null);
+  }, []);
+
+  return {
+    email,
+    isValidEmail,
+    handleEmailChange,
+  };
+}

--- a/src/utils/constant.ts
+++ b/src/utils/constant.ts
@@ -1,0 +1,16 @@
+/** 권한 관련 */
+const ACCESS_TOKEN = btoa("FLOWBIT_ACT");
+
+/** 회원가입 관련 */
+const EMAIL_PURPOSE = {
+  SIGNUP: "SIGNUP",
+  SUBSCRIBE: "SUBSCRIBE",
+} as const;
+
+/** 소셜 로그인 관련 */
+const OAUTH = {
+  KAKAO: `${import.meta.env.VITE_API_URL}/user-service/oauth2/authorization/kakao`,
+  GOOGLE: `${import.meta.env.VITE_API_URL}/user-service/oauth2/authorization/google`,
+};
+
+export { ACCESS_TOKEN, EMAIL_PURPOSE, OAUTH };


### PR DESCRIPTION
**목적**
- 소셜 로그인 시에 정상적인 토큰 값이 들어와도 401 에러를 뱉는 현상을 수정해요
- 회원가입 로직 일부를 리팩토링해요

**작업 내용**
- src/api/index.ts
src/utils/constant.ts
src/app/signin/index.tsx
src/components/layout/header.tsx
  - 기존에는 토큰 이름을 `FLOWBIT_ACT` 이라고 명명했는데 너무 명시적으로 이름을 설정하는걸 방지하고자 ASCII 문자열로 변경했어요 
 
- src/hooks/useCheckEmail.ts
  - 뉴스레터 구독, 회원가입 쪽에서 이메일 인증 체크하는 부분이 있는데 이 부분을 공통적으로 사용하기 위한 커스텀 훅을 제작했어요 
- src/utils/constant.ts
  - 환경변수 일부를 설정했어요

**필수 리뷰어**
- @klmhyeonwoo, @Cllaude99 ,@joeunSong

**이슈 번호**
-  #105 
